### PR TITLE
fix: convert wall slot coords to center pillar before sending to backend

### DIFF
--- a/app/games/[gameId]/page.tsx
+++ b/app/games/[gameId]/page.tsx
@@ -126,7 +126,9 @@ export default function GamePage() {
   async function handleWall(matrixRow: number, matrixCol: number, orientation: "HORIZONTAL" | "VERTICAL") {
     if (!isMyTurn) return;
     try {
-      await api.post(`/games/${gameId}/wall`, { targetField: [matrixRow, matrixCol], orientation });
+      const centerRow = orientation === "HORIZONTAL" ? matrixRow     : matrixRow + 1;
+      const centerCol = orientation === "HORIZONTAL" ? matrixCol + 1 : matrixCol;
+      await api.post(`/games/${gameId}/wall`, { targetField: [centerRow, centerCol], orientation });
       fetchGame();
     } catch {
       setError("Invalid wall placement.");


### PR DESCRIPTION
The frontend was sending the clicked wall slot's position (odd, even) or (even, odd) directly to the backend, but the backend expects the wall's center pillar at (odd, odd). The fix adds an offset of +1 to the column (horizontal) or row (vertical) to compute the correct center.